### PR TITLE
Fix Ore Spawning

### DIFF
--- a/src/generated/resources/data/tool_forge/forge/biome_modifier/add_bismuth_ore.json
+++ b/src/generated/resources/data/tool_forge/forge/biome_modifier/add_bismuth_ore.json
@@ -1,0 +1,6 @@
+{
+  "type": "forge:add_features",
+  "biomes": "#minecraft:is_overworld",
+  "features": "tool_forge:bismuth_ore_placed",
+  "step": "underground_ores"
+}

--- a/src/generated/resources/data/tool_forge/forge/biome_modifier/add_end_bismuth_ore.json
+++ b/src/generated/resources/data/tool_forge/forge/biome_modifier/add_end_bismuth_ore.json
@@ -1,0 +1,6 @@
+{
+  "type": "forge:add_features",
+  "biomes": "#minecraft:is_end",
+  "features": "tool_forge:end_bismuth_ore_placed",
+  "step": "underground_ores"
+}

--- a/src/generated/resources/data/tool_forge/forge/biome_modifier/add_end_lillium_ore.json
+++ b/src/generated/resources/data/tool_forge/forge/biome_modifier/add_end_lillium_ore.json
@@ -1,0 +1,6 @@
+{
+  "type": "forge:add_features",
+  "biomes": "#minecraft:is_end",
+  "features": "tool_forge:end_lillium_ore_placed",
+  "step": "underground_ores"
+}

--- a/src/generated/resources/data/tool_forge/forge/biome_modifier/spawn_soul.json
+++ b/src/generated/resources/data/tool_forge/forge/biome_modifier/spawn_soul.json
@@ -5,6 +5,6 @@
     "type": "tool_forge:soul",
     "maxCount": 2,
     "minCount": 1,
-    "weight": 1
+    "weight": 6
   }
 }

--- a/src/generated/resources/data/tool_forge/worldgen/configured_feature/bismuth_ore.json
+++ b/src/generated/resources/data/tool_forge/worldgen/configured_feature/bismuth_ore.json
@@ -1,0 +1,27 @@
+{
+  "type": "minecraft:ore",
+  "config": {
+    "discard_chance_on_air_exposure": 0.0,
+    "size": 5,
+    "targets": [
+      {
+        "state": {
+          "Name": "tool_forge:bismuth_ore"
+        },
+        "target": {
+          "predicate_type": "minecraft:tag_match",
+          "tag": "minecraft:stone_ore_replaceables"
+        }
+      },
+      {
+        "state": {
+          "Name": "tool_forge:deepslate_bismuth_ore"
+        },
+        "target": {
+          "predicate_type": "minecraft:tag_match",
+          "tag": "minecraft:deepslate_ore_replaceables"
+        }
+      }
+    ]
+  }
+}

--- a/src/generated/resources/data/tool_forge/worldgen/configured_feature/end_bismuth_ore.json
+++ b/src/generated/resources/data/tool_forge/worldgen/configured_feature/end_bismuth_ore.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:ore",
+  "config": {
+    "discard_chance_on_air_exposure": 0.0,
+    "size": 4,
+    "targets": [
+      {
+        "state": {
+          "Name": "tool_forge:bismuth_endstone_ore"
+        },
+        "target": {
+          "block": "minecraft:end_stone",
+          "predicate_type": "minecraft:block_match"
+        }
+      }
+    ]
+  }
+}

--- a/src/generated/resources/data/tool_forge/worldgen/configured_feature/end_lillium_ore.json
+++ b/src/generated/resources/data/tool_forge/worldgen/configured_feature/end_lillium_ore.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:ore",
+  "config": {
+    "discard_chance_on_air_exposure": 0.0,
+    "size": 3,
+    "targets": [
+      {
+        "state": {
+          "Name": "tool_forge:lillium_ore"
+        },
+        "target": {
+          "block": "minecraft:end_stone",
+          "predicate_type": "minecraft:block_match"
+        }
+      }
+    ]
+  }
+}

--- a/src/generated/resources/data/tool_forge/worldgen/placed_feature/bismuth_ore_placed.json
+++ b/src/generated/resources/data/tool_forge/worldgen/placed_feature/bismuth_ore_placed.json
@@ -1,0 +1,27 @@
+{
+  "feature": "tool_forge:bismuth_ore",
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": 4
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:height_range",
+      "height": {
+        "type": "minecraft:trapezoid",
+        "max_inclusive": {
+          "absolute": 65
+        },
+        "min_inclusive": {
+          "absolute": -64
+        }
+      }
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/generated/resources/data/tool_forge/worldgen/placed_feature/end_bismuth_ore_placed.json
+++ b/src/generated/resources/data/tool_forge/worldgen/placed_feature/end_bismuth_ore_placed.json
@@ -1,0 +1,27 @@
+{
+  "feature": "tool_forge:end_bismuth_ore",
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": 2
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:height_range",
+      "height": {
+        "type": "minecraft:uniform",
+        "max_inclusive": {
+          "absolute": 80
+        },
+        "min_inclusive": {
+          "absolute": -64
+        }
+      }
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/generated/resources/data/tool_forge/worldgen/placed_feature/end_lillium_ore_placed.json
+++ b/src/generated/resources/data/tool_forge/worldgen/placed_feature/end_lillium_ore_placed.json
@@ -1,0 +1,27 @@
+{
+  "feature": "tool_forge:end_lillium_ore",
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": 1
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:height_range",
+      "height": {
+        "type": "minecraft:uniform",
+        "max_inclusive": {
+          "absolute": 80
+        },
+        "min_inclusive": {
+          "absolute": -64
+        }
+      }
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/main/java/net/ZuperZV/Tool_Forge/datagen/ModWorldGenProvider.java
+++ b/src/main/java/net/ZuperZV/Tool_Forge/datagen/ModWorldGenProvider.java
@@ -2,8 +2,11 @@ package net.ZuperZV.Tool_Forge.datagen;
 
 import net.ZuperZV.Tool_Forge.Tool_Forge;
 import net.ZuperZV.Tool_Forge.worldgen.ModBiomeModifiers;
+import net.ZuperZV.Tool_Forge.worldgen.ModConfiguredFeatures;
+import net.ZuperZV.Tool_Forge.worldgen.ModPlacedFeatures;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.RegistrySetBuilder;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraftforge.common.data.DatapackBuiltinEntriesProvider;
@@ -14,6 +17,8 @@ import java.util.concurrent.CompletableFuture;
 
 public class ModWorldGenProvider extends DatapackBuiltinEntriesProvider {
     public static final RegistrySetBuilder BUILDER = new RegistrySetBuilder()
+            .add(Registries.CONFIGURED_FEATURE, ModConfiguredFeatures::bootstrap)
+            .add(Registries.PLACED_FEATURE, ModPlacedFeatures::bootstrap)
             .add(ForgeRegistries.Keys.BIOME_MODIFIERS, ModBiomeModifiers::bootstrap);
 
     public ModWorldGenProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {

--- a/src/main/java/net/ZuperZV/Tool_Forge/worldgen/ModBiomeModifiers.java
+++ b/src/main/java/net/ZuperZV/Tool_Forge/worldgen/ModBiomeModifiers.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class ModBiomeModifiers {
     public static final ResourceKey<BiomeModifier> SPAWN_SOUL = registerKey("spawn_soul");
 
-    public static final ResourceKey<BiomeModifier> ADD_BISMUTH_ORE = registerKey("add_alexandrite_ore");
+    public static final ResourceKey<BiomeModifier> ADD_BISMUTH_ORE = registerKey("add_bismuth_ore");
     public static final ResourceKey<BiomeModifier> ADD_END_BISMUTH_ORE = registerKey("add_end_bismuth_ore");
     public static final ResourceKey<BiomeModifier> ADD_END_LILLIUM_ORE = registerKey("add_end_lillium_ore");
 


### PR DESCRIPTION
Fix the ore spawning by adding `ModConfiguredFeatures::bootstrap` and `ModPlacedFeatures::bootstrap` to ModWorldGenProvider

(also changed your ADD_BISMUTH_ORE registry key to "add_bismuth_ore" instead of "add_alexandrite_ore" 😉 )